### PR TITLE
Fix fixup 

### DIFF
--- a/lib/DBIx/Connector.pm
+++ b/lib/DBIx/Connector.pm
@@ -156,6 +156,7 @@ sub _run {
         local $@;
         my $dbh = $self->{_mode} eq 'ping' ? $self->dbh : $self->_dbh;
         local $self->{_in_run} = 1;
+        local $dbh->{RaiseError} = 1;
         @ret = eval { _exec( $dbh, $code, $wantarray ) };
         $err = $@;
     }
@@ -178,6 +179,7 @@ sub _fixup_run {
     my $err;
     TRY: {
         local $@;
+        local $dbh->{RaiseError} = 1;
         @ret = eval { _exec( $dbh, $code, $wantarray ) };
         $err = $@;
     }
@@ -187,6 +189,7 @@ sub _fixup_run {
         # Not connected. Try again.
         TRY: {
             local $@;
+            local $dbh->{RaiseError} = 1;
             @ret = eval { _exec( $self->_connect, $code, $wantarray ) };
             $err = $@;
         }
@@ -227,6 +230,7 @@ sub _txn_run {
 
     TRY: {
         local $@;
+        local $dbh->{RaiseError} = 1;
         eval {
             local $self->{_in_run}  = 1;
             $driver->begin_work($dbh);
@@ -261,6 +265,7 @@ sub _txn_fixup_run {
     my $err;
     TRY: {
         local $@;
+        local $dbh->{RaiseError} = 1;
         eval {
             $driver->begin_work($dbh);
             @ret = _exec( $dbh, $code, $wantarray );
@@ -278,6 +283,7 @@ sub _txn_fixup_run {
         TRY: {
             local $@;
             $dbh = $self->_connect;
+            local $dbh->{RaiseError} = 1;
             eval {
                 $driver->begin_work($dbh);
                 @ret = _exec( $dbh, $code, $wantarray );
@@ -314,6 +320,7 @@ sub svp {
 
     TRY: {
         local $@;
+        local $dbh->{RaiseError} = 1;
         eval {
             $driver->savepoint($dbh, $name);
             @ret = _exec( $dbh, $code, $wantarray );

--- a/t/run_fixup.t
+++ b/t/run_fixup.t
@@ -75,7 +75,7 @@ $conn->run( fixup => sub {
     my $dbha = shift;
     ok $conn->{_in_run}, '_in_run should be true';
     $calls++;
-    if ($die) {
+    if ($die && $dbha->{RaiseError}) {
         is $_, $dbh, 'Should have dbh in $_';
         is $dbha, $dbh, 'Should have stored dbh';
         $ping = 0;


### PR DESCRIPTION
Hi David!

I and one more developer - nuclon - found, that in fixup mode DBIx::Connector does not reconnect to database, as it expected.

After little investigation i've found that $dbh doesn't die on error, but returns undef as its described at http://search.cpan.org/~timb/DBI-1.615/DBI.pm#RaiseError

Test, i've midified may be not so obvious, so i provude real world test:

```
use strict;
use warnings;

use DBIx::Connector;

my $c = DBIx::Connector->new('dbi:mysql:test') or die "No DB connection";


print "First query: " . 
    $c->run(fixup => sub { shift->selectrow_array('SELECT 1')}), "\n";

sleep(10);

print "Second query: " . 
    $c->run(fixup => sub { shift->selectrow_array('SELECT 1')}), "\n";
```

This test written against mysql server and befor run it you have to set up appropriate timeout in your my.ini

```
[mysqld]

wait_timeout=5
```

And restart mysql server.

I think, similar test can be written against SQLite (removing sqlite file before second query) but i'm not sure.

Patch should solve the problem.
