### PR TITLE
My fix as i think ;-)

### DIFF
--- a/lib/DBIx/Connector.pm
+++ b/lib/DBIx/Connector.pm
@@ -543,16 +543,16 @@ For example:
 
     use Try::Tiny;
     try {
-	$conn->txn(sub {
-	    # ...
-	});
+        $conn->txn(sub {
+            # ...
+        });
     } catch {
-	if (eval { $_->isa('DBIx::Connector::RollbackError') }) {
-	    say STDERR 'Transaction aborted: ', $_->error;
-	    say STDERR 'Rollback failed too: ', $_->rollback_error;
-	} else {
-	    warn "Caught exception: $_";
-	}
+        if (eval { $_->isa('DBIx::Connector::RollbackError') }) {
+            say STDERR 'Transaction aborted: ', $_->error;
+            say STDERR 'Rollback failed too: ', $_->rollback_error;
+        } else {
+            warn "Caught exception: $_";
+        }
     };
 
 If a L<C<svp()>|/"svp"> rollback fails and its surrounding L<C<txn()>|/"txn">


### PR DESCRIPTION
In this example i think try & catch blocks should be outside txn because this exceptions are raised in _rollback ( https://metacpan.org/source/DWHEELER/DBIx-Connector-0.53/lib/DBIx/Connector.pm, line 215 ) after execution txn block but not in inside user's block (unless txn block has inside other txn block but i think this example not about this cause)
