### PR TITLE
Add support for MariaDB

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Release history for DBIx-Connector
 
+0.59  Tue 23 Jul 2024
+      - Added MariaDB support, thanks to Perlover
+
 0.59  Sun 02 Jul 2023
       - Fix for Windows t/load.t failures
 

--- a/lib/DBIx/Connector.pm
+++ b/lib/DBIx/Connector.pm
@@ -5,7 +5,7 @@ package DBIx::Connector;
 use DBI '1.605';
 use DBIx::Connector::Driver;
 
-our $VERSION = '0.59';
+our $VERSION = '0.60';
 
 sub new {
     my $class = shift;
@@ -652,6 +652,8 @@ for the drivers for details:
 =item L<DBIx::Connector::Driver::SQLite>
 
 =item L<DBIx::Connector::Driver::mysql>
+
+=item L<DBIx::Connector::Driver::MariaDB>
 
 =item L<DBIx::Connector::Driver::Firebird>
 

--- a/lib/DBIx/Connector/Driver.pm
+++ b/lib/DBIx/Connector/Driver.pm
@@ -2,7 +2,7 @@ use strict; use warnings;
 
 package DBIx::Connector::Driver;
 
-our $VERSION = '0.59';
+our $VERSION = '0.60';
 
 DRIVERS: {
     my %DRIVERS;

--- a/lib/DBIx/Connector/Driver/Firebird.pm
+++ b/lib/DBIx/Connector/Driver/Firebird.pm
@@ -4,7 +4,7 @@ package DBIx::Connector::Driver::Firebird;
 
 use DBIx::Connector::Driver;
 
-our $VERSION = '0.59';
+our $VERSION = '0.60';
 our @ISA = qw( DBIx::Connector::Driver );
 
 sub savepoint {

--- a/lib/DBIx/Connector/Driver/MSSQL.pm
+++ b/lib/DBIx/Connector/Driver/MSSQL.pm
@@ -4,7 +4,7 @@ package DBIx::Connector::Driver::MSSQL;
 
 use DBIx::Connector::Driver;
 
-our $VERSION = '0.59';
+our $VERSION = '0.60';
 our @ISA = qw( DBIx::Connector::Driver );
 
 sub savepoint {

--- a/lib/DBIx/Connector/Driver/MariaDB.pm
+++ b/lib/DBIx/Connector/Driver/MariaDB.pm
@@ -1,6 +1,6 @@
 use strict; use warnings;
 
-package DBIx::Connector::Driver::mysql;
+package DBIx::Connector::Driver::MariaDB;
 
 use DBIx::Connector::Driver;
 
@@ -9,7 +9,7 @@ our @ISA = qw( DBIx::Connector::Driver );
 
 sub _connect {
     my ($self, $dbh) = @_;
-    $dbh->{mysql_auto_reconnect} = 0;
+    $dbh->{mariadb_auto_reconnect} = 0;
     $dbh;
 }
 
@@ -34,12 +34,12 @@ __END__
 
 =head1 NAME
 
-DBIx::Connector::Driver::mysql - MySQL-specific connection interface
+DBIx::Connector::Driver::MariaDB - MariaDB-specific connection interface
 
 =head1 DESCRIPTION
 
 This subclass of L<DBIx::Connector::Driver|DBIx::Connector::Driver> provides
-MySQL-specific implementations of the following methods:
+MariaDB-specific implementations of the following methods:
 
 =over
 
@@ -55,9 +55,9 @@ It also modifies the connection attributes as follows:
 
 =over
 
-=item C<mysql_auto_reconnect>
+=item C<mariadb_auto_reconnect>
 
-Will always be set to false. This is to prevent MySQL's auto-reconnection
+Will always be set to false. This is to prevent MariaDB's auto-reconnection
 feature from interfering with DBIx::Connector's auto-reconnection
 functionality in C<fixup> mode.
 

--- a/lib/DBIx/Connector/Driver/Oracle.pm
+++ b/lib/DBIx/Connector/Driver/Oracle.pm
@@ -4,7 +4,7 @@ package DBIx::Connector::Driver::Oracle;
 
 use DBIx::Connector::Driver;
 
-our $VERSION = '0.59';
+our $VERSION = '0.60';
 our @ISA = qw( DBIx::Connector::Driver );
 
 # Note from https://rt.cpan.org/Ticket/Display.html?id=47005:

--- a/lib/DBIx/Connector/Driver/Pg.pm
+++ b/lib/DBIx/Connector/Driver/Pg.pm
@@ -4,7 +4,7 @@ package DBIx::Connector::Driver::Pg;
 
 use DBIx::Connector::Driver;
 
-our $VERSION = '0.59';
+our $VERSION = '0.60';
 our @ISA = qw( DBIx::Connector::Driver );
 
 sub savepoint {

--- a/lib/DBIx/Connector/Driver/SQLite.pm
+++ b/lib/DBIx/Connector/Driver/SQLite.pm
@@ -4,7 +4,7 @@ package DBIx::Connector::Driver::SQLite;
 
 use DBIx::Connector::Driver;
 
-our $VERSION = '0.59';
+our $VERSION = '0.60';
 our @ISA = qw( DBIx::Connector::Driver );
 
 sub _connect {


### PR DESCRIPTION
Related issue: https://github.com/ap/DBIx-Connector/issues/50

I also have a need to use the [DBD::MariaDB](https://metacpan.org/pod/DBD::MariaDB) driver.

The thing is that the latest versions of MariaDB do not work under `DBD::mysql`. The only way out is to use `DBD::MariaDB`. But without this patch we can't use your module.

I took a copy of the DBD::mysql code, patched it as it should be and corrected the version numbers and Changes.

I haven't tested the code, but I think it will probably work. If you can test, please do so before release.
